### PR TITLE
Add whois fallback after RDAP errors

### DIFF
--- a/src/adapters/whoisApiAdapter.ts
+++ b/src/adapters/whoisApiAdapter.ts
@@ -1,0 +1,55 @@
+import { CheckerAdapter, DomainStatus } from '../types.js';
+
+export class WhoisApiAdapter implements CheckerAdapter {
+  private freaksKey?: string;
+  private xmlKey?: string;
+  constructor(freaksKey?: string, xmlKey?: string) {
+    this.freaksKey = freaksKey;
+    this.xmlKey = xmlKey;
+  }
+
+  private async fetchFreaks(domain: string, signal?: AbortSignal): Promise<any> {
+    if (!this.freaksKey) throw new Error('whoisfreaks api key missing');
+    const url = `https://api.whoisfreaks.com/v1.0/whois?apiKey=${this.freaksKey}&whois=live&domain=${domain}`;
+    const res = await fetch(url, { signal });
+    const text = await res.text();
+    if (!res.ok) {
+      const err: any = new Error(`whoisfreaks failed: ${res.status}`);
+      err.quota = res.status === 429 || /quota|limit/i.test(text);
+      throw err;
+    }
+    return JSON.parse(text);
+  }
+
+  private async fetchXml(domain: string, signal?: AbortSignal): Promise<any> {
+    if (!this.xmlKey) throw new Error('whoisxml api key missing');
+    const url = `https://www.whoisxmlapi.com/whoisserver/WhoisService?apiKey=${this.xmlKey}&domainName=${domain}&outputFormat=JSON`;
+    const res = await fetch(url, { signal });
+    const text = await res.text();
+    if (!res.ok) throw new Error(`whoisxml failed: ${res.status}`);
+    return JSON.parse(text);
+  }
+
+  async check(domain: string, opts: { signal?: AbortSignal } = {}): Promise<DomainStatus> {
+    let data: any;
+    try {
+      data = await this.fetchFreaks(domain, opts.signal);
+    } catch (err: any) {
+      if (err.quota) {
+        data = await this.fetchXml(domain, opts.signal);
+      } else {
+        throw err;
+      }
+    }
+
+    const text = JSON.stringify(data).toLowerCase();
+    const isAvailable = text.includes('n/a') || text.includes('no match') || text.includes('not found');
+    return {
+      domain,
+      availability: isAvailable ? 'available' : 'unavailable',
+      source: 'whois-api',
+      raw: data,
+      timestamp: Date.now(),
+    };
+  }
+}

--- a/src/adapters/whoisCliAdapter.ts
+++ b/src/adapters/whoisCliAdapter.ts
@@ -1,0 +1,27 @@
+import { CheckerAdapter, DomainStatus } from '../types.js';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+
+const execAsync = promisify(exec);
+
+export class WhoisCliAdapter implements CheckerAdapter {
+  async check(domain: string): Promise<DomainStatus> {
+    const cmd = `whois ${domain}`;
+    const { stdout } = await execAsync(cmd, { maxBuffer: 1024 * 1024 });
+    const text = stdout.toLowerCase();
+    const availablePatterns = [
+      'no match',
+      'not found',
+      'no entries found',
+      'status: available',
+    ];
+    const isAvailable = availablePatterns.some((p) => text.includes(p));
+    return {
+      domain,
+      availability: isAvailable ? 'available' : 'unavailable',
+      source: 'whois-lib',
+      raw: stdout,
+      timestamp: Date.now(),
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- add adapters for whois CLI and API
- fall back to whois when RDAP lookup fails
- adjust WhoisApiAdapter constructor and fallback logic
- use whois CLI only on Node.js, API only on web

## Testing
- `npm run build`
- `npm test` *(fails: fetch errors and whois CLI not found)*

------
https://chatgpt.com/codex/tasks/task_b_68866071044483268f6b40e2211949f7