### PR TITLE
Implement adapter filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ export {
 export function configure(opts: {
   logger?: Logger;
   concurrency?: number;
+  /** Only run adapters whose namespace starts with one of these prefixes */
+  only?: string[];
+  /** Skip adapters whose namespace starts with one of these prefixes */
+  skip?: string[];
 }) { … }
 ```
 
@@ -80,7 +84,7 @@ export function configure(opts: {
 * Fix whois fallback, perhaps using whois-json library.
 * Expand ccTLD list to include all ccTLDs.
 * Add namespace to adapters, use it to store raw responses.
-* Implement `only` and `skip` config options, using namespaces
+* ~~Implement `only` and `skip` config options, using namespaces~~
 * ~~Implement per-adapter timeouts~~
 
 ## Running the Demo


### PR DESCRIPTION
## Summary
- add `only` and `skip` configuration options
- respect new adapter filtering options
- document how to use adapter filters
- test the new filter options

## Testing
- `npm run build`
- `npm test` *(fails: ENETUNREACH and missing `whois` command)*

------
https://chatgpt.com/codex/tasks/task_b_688d2a1cb23c8326a19dc08648f31c94