### PR TITLE
refactor: reuse parsed domain across adapters

### DIFF
--- a/src/adapters/dohAdapter.ts
+++ b/src/adapters/dohAdapter.ts
@@ -1,4 +1,4 @@
-import { CheckerAdapter, AdapterResponse } from '../types';
+import { CheckerAdapter, AdapterResponse, ParsedDomain } from '../types';
 
 const DEFAULT_TIMEOUT_MS = 200;
 
@@ -9,7 +9,8 @@ export class DohAdapter implements CheckerAdapter {
     this.url = url;
   }
 
-  async check(domain: string, opts: { timeoutMs?: number } = {}): Promise<AdapterResponse> {
+  async check(domainObj: ParsedDomain, opts: { timeoutMs?: number } = {}): Promise<AdapterResponse> {
+    const domain = domainObj.domain as string;
     const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     const ac = new AbortController();
     const timer = setTimeout(() => ac.abort(), timeoutMs);

--- a/src/adapters/hostAdapter.ts
+++ b/src/adapters/hostAdapter.ts
@@ -1,11 +1,12 @@
-import { CheckerAdapter, AdapterResponse } from '../types';
+import { CheckerAdapter, AdapterResponse, ParsedDomain } from '../types';
 import { promises as dns } from 'dns';
 
 const DEFAULT_TIMEOUT_MS = 300;
 
 export class HostAdapter implements CheckerAdapter {
   namespace = 'dns.host';
-  async check(domain: string, opts: { timeoutMs?: number } = {}): Promise<AdapterResponse> {
+  async check(domainObj: ParsedDomain, opts: { timeoutMs?: number } = {}): Promise<AdapterResponse> {
+    const domain = domainObj.domain as string;
     const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     const timer = new Promise((_, reject) =>
       setTimeout(() => reject(new Error('timeout')), timeoutMs)

--- a/src/adapters/rdapAdapter.ts
+++ b/src/adapters/rdapAdapter.ts
@@ -1,4 +1,4 @@
-import { CheckerAdapter, AdapterResponse, TldConfigEntry } from '../types';
+import { CheckerAdapter, AdapterResponse, TldConfigEntry, ParsedDomain } from '../types';
 
 const DEFAULT_TIMEOUT_MS = 600;
 
@@ -10,9 +10,10 @@ export class RdapAdapter implements CheckerAdapter {
   }
 
   async check(
-    domain: string,
+    domainObj: ParsedDomain,
     opts: { timeoutMs?: number; tldConfig?: TldConfigEntry } = {}
   ): Promise<AdapterResponse> {
+    const domain = domainObj.domain as string;
     const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     const baseUrl = opts.tldConfig?.rdapServer || this.baseUrl;
     const ac = new AbortController();

--- a/src/adapters/whoisApiAdapter.ts
+++ b/src/adapters/whoisApiAdapter.ts
@@ -1,4 +1,4 @@
-import { CheckerAdapter, AdapterResponse } from '../types';
+import { CheckerAdapter, AdapterResponse, ParsedDomain } from '../types';
 
 const DEFAULT_TIMEOUT_MS = 1000;
 
@@ -39,7 +39,8 @@ export class WhoisApiAdapter implements CheckerAdapter {
     return JSON.parse(text);
   }
 
-  async check(domain: string, opts: { timeoutMs?: number } = {}): Promise<AdapterResponse> {
+  async check(domainObj: ParsedDomain, opts: { timeoutMs?: number } = {}): Promise<AdapterResponse> {
+    const domain = domainObj.domain as string;
     const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     try {
       let data: any;

--- a/src/adapters/whoisCliAdapter.ts
+++ b/src/adapters/whoisCliAdapter.ts
@@ -1,4 +1,4 @@
-import { CheckerAdapter, AdapterResponse } from '../types';
+import { CheckerAdapter, AdapterResponse, ParsedDomain } from '../types';
 import { exec } from 'child_process';
 import { promisify } from 'util';
 
@@ -8,7 +8,8 @@ const execAsync = promisify(exec);
 
 export class WhoisCliAdapter implements CheckerAdapter {
   namespace = 'whois.lib';
-  async check(domain: string, opts: { timeoutMs?: number } = {}): Promise<AdapterResponse> {
+  async check(domainObj: ParsedDomain, opts: { timeoutMs?: number } = {}): Promise<AdapterResponse> {
+    const domain = domainObj.domain as string;
     const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     try {
       const cmd = `whois ${domain}`;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import type { ParseResult } from 'tldts';
 
 export type Availability =
   | 'available'
@@ -52,11 +53,13 @@ export interface DomainStatus {
   error?: Error;
 }
 
+export type ParsedDomain = ParseResult;
+
 export interface CheckerAdapter {
   /** Unique identifier used to store results for this adapter */
   namespace: string;
   check(
-    domain: string,
+    domainObj: ParsedDomain,
     opts?: { timeoutMs?: number; tldConfig?: TldConfigEntry }
   ): Promise<AdapterResponse>;
 }

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -6,26 +6,26 @@ const tldMap: Record<string, string | boolean> = {
   ...(tlds as any).ccTLDs,
   ...(tlds as any).SLDs,
 };
-import { DomainStatus } from "./types.js";
-import { parse } from "tldts";
+import { DomainStatus, ParsedDomain } from "./types.js";
 
-export function validateDomain(domain: string): DomainStatus {
-  const parsed = parse(domain.toLowerCase());
+export function validateDomain(parsed: ParsedDomain): DomainStatus {
   if (
     !parsed.domain ||
     !parsed.publicSuffix ||
-    domain.trim() !== parsed.domain
+    parsed.hostname !== parsed.domain
   ) {
     return {
-      domain,
+      domain: parsed.hostname || "",
       availability: "invalid",
       resolver: "validator",
       raw: { validator: null },
       error: new Error(
-        `Parse error: input: ${domain}, parsedName: ${parsed.domain}, tld: ${parsed.publicSuffix}`
+        `Parse error: input: ${parsed.hostname}, parsedName: ${parsed.domain}, tld: ${parsed.publicSuffix}`
       ),
     };
   }
+
+  const domain = parsed.domain;
 
   if (!parsed.isIcann) {
     return {


### PR DESCRIPTION
## Summary
- parse domain in `check` once and validate using the parsed object
- centralize parse validation inside `validateDomain`
- update adapters to accept the parsed domain as `domainObj`

## Testing
- `npm test` *(fails: network lookups unavailable)*

------
https://chatgpt.com/codex/tasks/task_b_689f22515ab883269d5ec470c3108aca