### PR TITLE
feat: add streaming batch API

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,12 @@ To achieve both speed and accuracy under varying environments (Node.js vs browse
 ## Public API
 
 ```ts
-import { check, checkBatch } from './index';
+import { check, checkBatch, checkBatchStream } from './index';
 
 export {
   check,
   checkBatch,
+  checkBatchStream,
 };
 ```
 
@@ -60,6 +61,7 @@ interface CheckOptions {
 
 check(domain: string, options?: CheckOptions);
 checkBatch(domains: string[], options?: CheckOptions);
+checkBatchStream(domains: string[], options?: CheckOptions): AsyncGenerator<DomainStatus>;
 ```
 
 Logging is disabled by default; pass `verbose: true` to enable log output.
@@ -86,7 +88,6 @@ Node or browser-specific adapters.
 * Implement rdap overrides for TLDs that are not rdap conformant like .ng
   * .ng registry https://whois.nic.net.ng/domains?name=jiji.ng&exactMatch=true
 * Fix whois fallback, perhaps using whois-json library.
-* Add streaming API for batch calls
 
 ## Running the Demo
 


### PR DESCRIPTION
## Summary
- add `checkBatchStream` async generator for streaming domain checks
- refactor `checkBatch` to gather results from streaming API
- document streaming batch usage and expand tests
- simplify `checkBatch` result collection by removing redundant index mapping

## Testing
- `npm test` *(fails: whois: not found)*

------
https://chatgpt.com/codex/tasks/task_b_689f67dbe12c832681821e2cb9c704d6