### PR TITLE
Use tlds from tlds.json in tests

### DIFF
--- a/tests/run.test.js
+++ b/tests/run.test.js
@@ -1,6 +1,7 @@
 import test from 'ava';
 import { checkBatchStream } from '../dist/index.js';
 import unavailableDomainsJson from '../src/unavailable-domains.json' with { type: 'json' };
+import tldsJson from '../src/tlds.json' with { type: 'json' };
 
 const unavailableMap = {
   ...unavailableDomainsJson.popular,
@@ -34,7 +35,14 @@ async function runTest(domains, opts = {}) {
   return { pass, total: uniqueNames.length };
 }
 
-const testTlds = ['com', 'net', 'org', 'info', 'dev'];
+const tldMap = {
+  ...tldsJson.popular,
+  ...tldsJson.gTLDs,
+  ...tldsJson.ccTLDs,
+  ...tldsJson.SLDs,
+};
+
+const testTlds = Object.keys(tldMap).filter((tld) => unavailableMap[tld]);
 
 test.serial('validator tests', async (t) => {
   const specialDomains = [


### PR DESCRIPTION
## Summary
- Source test TLDs from `src/tlds.json` and filter to those with known unavailable domains
- Map each TLD to `this-domain-should-not-exist-12345.<tld>` for availability checks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689fb2d6b4788326b202d0f3a5effec9