### PR TITLE
Add .ng TLD/SLD availability tests

### DIFF
--- a/tests/run.test.js
+++ b/tests/run.test.js
@@ -127,6 +127,29 @@ test.serial('rdap tests', async (t) => {
   t.true(pass / total > 0.80);
 });
 
+test.serial('.ng TLD tests', async (t) => {
+  if (!(await hasNetwork())) {
+    t.log('Skipping .ng TLD tests due to lack of network access');
+    t.pass();
+    return;
+  }
+
+  const ngTlds = tldList.filter((tld) => tld === 'ng' || tld.endsWith('.ng'));
+  const availableDomains = ngTlds.map((tld) => ({
+    name: `this-domain-should-not-exist-12345.${tld}`,
+    availability: 'available',
+  }));
+  const unavailableDomains = ngTlds.map((tld) => ({
+    name: unavailableMap[tld],
+    availability: 'unavailable',
+  }));
+  const domains = [...availableDomains, ...unavailableDomains];
+  const { pass, total } = await runTest(domains);
+  console.log(`.ng test results: ${(pass * 100 / total).toFixed(2)}%`);
+  testSummary.ng = { pass, total };
+  t.true(pass / total > 0.80);
+});
+
 function printSummary() {
   console.log('\nTest Summary:');
   for (const [key, { pass, total }] of Object.entries(testSummary)) {


### PR DESCRIPTION
## Summary
- add dedicated tests for .ng TLDs and SLDs verifying available and unavailable domains

## Testing
- `npm test` *(skipped network-dependent checks)*

------
https://chatgpt.com/codex/tasks/task_b_689fd7b81b208326bb897f666adb4e34