### PR TITLE
feat: add cache support with optional disabling

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,13 @@ interface CheckOptions {
   skip?: string[];       // skip adapters whose namespace starts with these
   tldConfig?: TldConfigEntry;
   platform?: 'auto' | 'node' | 'browser';
+  cache?: boolean;      // enable or disable caching (default true)
 }
 ```
 
 Logging is disabled unless `verbose` is set. When `platform` is `auto` the
-library detects the runtime and chooses suitable adapters.
+library detects the runtime and chooses suitable adapters. Set `cache: false`
+to disable caching.
 
 ### WHOIS API Keys
 

--- a/src/adapters/dohAdapter.ts
+++ b/src/adapters/dohAdapter.ts
@@ -1,18 +1,22 @@
-import { CheckerAdapter, AdapterResponse, ParsedDomain } from '../types';
+import { AdapterResponse, ParsedDomain } from '../types';
+import { BaseCheckerAdapter } from './baseAdapter';
 
 const DEFAULT_TIMEOUT_MS = 1000;
 
 // If this host device has a WIFI DNS override, it would intefer with this adapter.
-export class DohAdapter implements CheckerAdapter {
-  namespace = 'dns.doh';
+export class DohAdapter extends BaseCheckerAdapter {
   private url: string;
   constructor(url = 'https://cloudflare-dns.com/dns-query') {
+    super('dns.doh');
     // TODO: Add google cloud dns as fallback - https://dns.google/resolve
     // Maybe use cloudflare for some A-K, and google for the rest?
     this.url = url;
   }
 
-  async check(domainObj: ParsedDomain, opts: { timeoutMs?: number } = {}): Promise<AdapterResponse> {
+  protected async doCheck(
+    domainObj: ParsedDomain,
+    opts: { timeoutMs?: number } = {},
+  ): Promise<AdapterResponse> {
     const domain = domainObj.domain as string;
     const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     const ac = new AbortController();
@@ -49,8 +53,7 @@ export class DohAdapter implements CheckerAdapter {
         raw: null,
         error: err,
       };
-    }
-    finally {
+    } finally {
       clearTimeout(timer);
     }
   }

--- a/src/adapters/hostAdapter.ts
+++ b/src/adapters/hostAdapter.ts
@@ -1,11 +1,17 @@
-import { CheckerAdapter, AdapterResponse, ParsedDomain } from '../types';
+import { AdapterResponse, ParsedDomain } from '../types';
 import { promises as dns } from 'dns';
+import { BaseCheckerAdapter } from './baseAdapter';
 
 const DEFAULT_TIMEOUT_MS = 1000;
 
-export class HostAdapter implements CheckerAdapter {
-  namespace = 'dns.host';
-  async check(domainObj: ParsedDomain, opts: { timeoutMs?: number } = {}): Promise<AdapterResponse> {
+export class HostAdapter extends BaseCheckerAdapter {
+  constructor() {
+    super('dns.host');
+  }
+  protected async doCheck(
+    domainObj: ParsedDomain,
+    opts: { timeoutMs?: number } = {},
+  ): Promise<AdapterResponse> {
     const domain = domainObj.domain as string;
     const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     const timer = new Promise((_, reject) =>

--- a/src/adapters/pingAdapter.ts
+++ b/src/adapters/pingAdapter.ts
@@ -1,6 +1,7 @@
-import { CheckerAdapter, AdapterResponse, ParsedDomain } from '../types';
+import { AdapterResponse, ParsedDomain } from '../types';
 import { exec } from 'child_process';
 import { promisify } from 'util';
+import { BaseCheckerAdapter } from './baseAdapter';
 
 const execAsync = promisify(exec);
 const DEFAULT_TIMEOUT_MS = 1000;
@@ -8,10 +9,15 @@ const DEFAULT_TIMEOUT_MS = 1000;
 // Do not use this adapter except for liveness checks.
 // Host is superior in speed, reliability and coverage.
 // The nodejs implementation is not better either https://www.npmjs.com/package/net-ping.
-export class PingAdapter implements CheckerAdapter {
-  namespace = 'dns.ping';
+export class PingAdapter extends BaseCheckerAdapter {
+  constructor() {
+    super('dns.ping');
+  }
 
-  async check(domainObj: ParsedDomain, opts: { timeoutMs?: number } = {}): Promise<AdapterResponse> {
+  protected async doCheck(
+    domainObj: ParsedDomain,
+    opts: { timeoutMs?: number } = {},
+  ): Promise<AdapterResponse> {
     const domain = domainObj.domain as string;
     const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     const cmd = `ping -c 1 ${domain}`;

--- a/src/adapters/rdapAdapter.ts
+++ b/src/adapters/rdapAdapter.ts
@@ -1,15 +1,16 @@
-import { CheckerAdapter, AdapterResponse, TldConfigEntry, ParsedDomain } from '../types';
+import { AdapterResponse, TldConfigEntry, ParsedDomain } from '../types';
+import { BaseCheckerAdapter } from './baseAdapter';
 
 const DEFAULT_TIMEOUT_MS = 3000;
 
-export class RdapAdapter implements CheckerAdapter {
-  namespace = 'rdap';
+export class RdapAdapter extends BaseCheckerAdapter {
   private baseUrl: string;
   constructor(baseUrl = 'https://rdap.org/domain/') {
+    super('rdap');
     this.baseUrl = baseUrl;
   }
 
-  async check(
+  protected async doCheck(
     domainObj: ParsedDomain,
     opts: { timeoutMs?: number; tldConfig?: TldConfigEntry } = {}
   ): Promise<AdapterResponse> {

--- a/src/adapters/whoisApiAdapter.ts
+++ b/src/adapters/whoisApiAdapter.ts
@@ -1,12 +1,13 @@
-import { CheckerAdapter, AdapterResponse, ParsedDomain } from '../types';
+import { AdapterResponse, ParsedDomain } from '../types';
+import { BaseCheckerAdapter } from './baseAdapter';
 
 const DEFAULT_TIMEOUT_MS = 1000;
 
-export class WhoisApiAdapter implements CheckerAdapter {
-  namespace = 'whois.api';
+export class WhoisApiAdapter extends BaseCheckerAdapter {
   private freaksKey?: string;
   private xmlKey?: string;
   constructor(freaksKey?: string, xmlKey?: string) {
+    super('whois.api');
     this.freaksKey = freaksKey;
     this.xmlKey = xmlKey;
   }
@@ -39,7 +40,10 @@ export class WhoisApiAdapter implements CheckerAdapter {
     return JSON.parse(text);
   }
 
-  async check(domainObj: ParsedDomain, opts: { timeoutMs?: number } = {}): Promise<AdapterResponse> {
+  protected async doCheck(
+    domainObj: ParsedDomain,
+    opts: { timeoutMs?: number } = {},
+  ): Promise<AdapterResponse> {
     const domain = domainObj.domain as string;
     const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     try {

--- a/src/adapters/whoisLibAdapter.ts
+++ b/src/adapters/whoisLibAdapter.ts
@@ -1,5 +1,6 @@
-import { CheckerAdapter, AdapterResponse, ParsedDomain } from '../types';
+import { AdapterResponse, ParsedDomain } from '../types';
 import whois from 'whois';
+import { BaseCheckerAdapter } from './baseAdapter';
 
 const DEFAULT_TIMEOUT_MS = 5000;
 
@@ -15,9 +16,14 @@ function lookup(domain: string, timeoutMs: number): Promise<string> {
   });
 }
 
-export class WhoisLibAdapter implements CheckerAdapter {
-  namespace = 'whois.lib';
-  async check(domainObj: ParsedDomain, opts: { timeoutMs?: number } = {}): Promise<AdapterResponse> {
+export class WhoisLibAdapter extends BaseCheckerAdapter {
+  constructor() {
+    super('whois.lib');
+  }
+  protected async doCheck(
+    domainObj: ParsedDomain,
+    opts: { timeoutMs?: number } = {},
+  ): Promise<AdapterResponse> {
     const domain = domainObj.domain as string;
     const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,7 +82,7 @@ export async function check(domain: string, opts: CheckOptions = {}): Promise<Do
     const dnsAdapter = tldAdapter?.dns ?? (isNode ? (usePing ? ping : host) : doh);
     if (adapterAllowed(dnsAdapter.namespace, opts)) {
       try {
-        dnsResult = await dnsAdapter.check(parsed);
+        dnsResult = await dnsAdapter.check(parsed, { cache: opts.cache });
       } catch (err: any) {
         dnsResult = {
           domain: name,
@@ -113,7 +113,10 @@ export async function check(domain: string, opts: CheckOptions = {}): Promise<Do
 
     const rdapAdapter = tldAdapter?.rdap ?? rdap;
     if (!opts.tldConfig?.skipRdap && adapterAllowed(rdapAdapter.namespace, opts)) {
-      const rdapRes = await rdapAdapter.check(parsed, { tldConfig: opts.tldConfig });
+      const rdapRes = await rdapAdapter.check(parsed, {
+        tldConfig: opts.tldConfig,
+        cache: opts.cache,
+      });
       raw[rdapAdapter.namespace] = rdapRes.raw;
       if (rdapRes.error) {
         logger.warn('rdap.failed', { domain: name, error: String(rdapRes.error) });
@@ -134,7 +137,7 @@ export async function check(domain: string, opts: CheckOptions = {}): Promise<Do
     let whoisRes: AdapterResponse | null = null;
     const whoisAdapter = tldAdapter?.whois ?? (isNode ? whoisLib : whoisApi);
     if (adapterAllowed(whoisAdapter.namespace, opts)) {
-      whoisRes = await whoisAdapter.check(parsed);
+      whoisRes = await whoisAdapter.check(parsed, { cache: opts.cache });
       raw[whoisAdapter.namespace] = whoisRes.raw;
       if (whoisRes.error) {
         logger.warn(

--- a/src/tldAdapters/ngAdapter.ts
+++ b/src/tldAdapters/ngAdapter.ts
@@ -1,14 +1,14 @@
-import { CheckerAdapter, AdapterResponse, ParsedDomain, AdapterSource } from '../types';
+import { AdapterResponse, ParsedDomain, AdapterSource } from '../types';
+import { BaseCheckerAdapter } from '../adapters/baseAdapter';
 
 const DEFAULT_TIMEOUT_MS = 3000;
 
-export class NgAdapter implements CheckerAdapter {
-  namespace: string;
+export class NgAdapter extends BaseCheckerAdapter {
   private source: AdapterSource;
 
   constructor(source: AdapterSource, namespace: string) {
+    super(namespace);
     this.source = source;
-    this.namespace = namespace;
   }
 
   private async query(domain: string, timeoutMs: number): Promise<{ exists: boolean; raw: any }> {
@@ -30,7 +30,7 @@ export class NgAdapter implements CheckerAdapter {
     }
   }
 
-  async check(
+  protected async doCheck(
     domainObj: ParsedDomain,
     opts: { timeoutMs?: number } = {}
   ): Promise<AdapterResponse> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,7 +61,7 @@ export interface CheckerAdapter {
   namespace: string;
   check(
     domainObj: ParsedDomain,
-    opts?: { timeoutMs?: number; tldConfig?: TldConfigEntry }
+    opts?: { timeoutMs?: number; tldConfig?: TldConfigEntry; cache?: boolean }
   ): Promise<AdapterResponse>;
 }
 
@@ -83,4 +83,8 @@ export interface CheckOptions {
    * Platform to run adapters on. Defaults to auto-detect based on environment.
    */
   platform?: Platform;
+  /**
+   * Enable or disable caching. Caching is enabled by default.
+   */
+  cache?: boolean;
 }


### PR DESCRIPTION
## Summary
- add BaseCheckerAdapter with namespaced caching and ability to disable
- allow adapters and public check to toggle cache usage
- require adapters to provide a namespace via the base constructor
- document cache option in README
- restore test suite to use default cache settings

## Testing
- `npm test` *(fails: 3 tests failed, network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_b_68a4c7c4672c8326beb69fb0738f99f5