### PR TITLE
feat: add AdapterError and retry-aware caching

### DIFF
--- a/src/adapters/baseAdapter.ts
+++ b/src/adapters/baseAdapter.ts
@@ -26,7 +26,7 @@ export abstract class BaseCheckerAdapter implements CheckerAdapter {
 
     const { cache, ...rest } = opts;
     const res = await this.doCheck(domainObj, rest);
-    if (cacheEnabled && !res.error) {
+    if (cacheEnabled && (!res.error || res.error.retryable === false)) {
       BaseCheckerAdapter.cache.set(key, res);
     }
     return res;

--- a/src/adapters/hostAdapter.ts
+++ b/src/adapters/hostAdapter.ts
@@ -45,15 +45,20 @@ export class HostAdapter extends BaseCheckerAdapter {
       //   };
       // }
 
-      const isTimeout = err.killed && err.signal === 'SIGTERM' && err.code === null;
+      const isTimeout =
+        err?.message === 'timeout' || (err.killed && err.signal === 'SIGTERM' && err.code === null);
       return {
         domain,
         availability: 'unknown',
         source: 'dns.host',
         raw: null,
-        error: isTimeout
-          ? new Error(`Timed out after ${timeoutMs}ms`)
-          : err,
+        error: {
+          code: isTimeout ? 'TIMEOUT' : err.code || 'DNS_HOST_ERROR',
+          message: isTimeout
+            ? `Timed out after ${timeoutMs}ms`
+            : err.message || String(err),
+          retryable: true,
+        },
       };
     }
   }

--- a/src/adapters/pingAdapter.ts
+++ b/src/adapters/pingAdapter.ts
@@ -45,7 +45,13 @@ export class PingAdapter extends BaseCheckerAdapter {
         availability: 'unknown',
         source: 'dns.ping',
         raw: null,
-        error: isTimeout ? new Error(`Timed out after ${timeoutMs}ms`) : err,
+        error: {
+          code: isTimeout ? 'TIMEOUT' : err.code || 'PING_ERROR',
+          message: isTimeout
+            ? `Timed out after ${timeoutMs}ms`
+            : err.message || String(err),
+          retryable: true,
+        },
       };
     }
   }

--- a/src/adapters/whoisLibAdapter.ts
+++ b/src/adapters/whoisLibAdapter.ts
@@ -35,7 +35,11 @@ export class WhoisLibAdapter extends BaseCheckerAdapter {
           availability: 'unknown',
           source: 'whois.lib',
           raw: text,
-          error: new Error(`TLD '${domainObj.publicSuffix}' is not supported for whois`),
+          error: {
+            code: 'UNSUPPORTED_TLD',
+            message: `TLD '${domainObj.publicSuffix}' is not supported for whois`,
+            retryable: false,
+          },
         };
       }
       const availablePatterns = [
@@ -60,7 +64,13 @@ export class WhoisLibAdapter extends BaseCheckerAdapter {
         availability: 'unknown',
         source: 'whois.lib',
         raw: null,
-        error: isTimeout ? new Error(`Timed out after ${timeoutMs}ms`) : err,
+        error: {
+          code: isTimeout ? 'TIMEOUT' : err.code || 'WHOIS_LIB_ERROR',
+          message: isTimeout
+            ? `Timed out after ${timeoutMs}ms`
+            : err.message || String(err),
+          retryable: true,
+        },
       };
     }
   }

--- a/src/tldAdapters/ngAdapter.ts
+++ b/src/tldAdapters/ngAdapter.ts
@@ -51,7 +51,13 @@ export class NgAdapter extends BaseCheckerAdapter {
         availability: 'unknown',
         source: this.namespace,
         raw: null,
-        error: isTimeout ? new Error(`Timed out after ${timeoutMs}ms`) : err,
+        error: {
+          code: isTimeout ? 'TIMEOUT' : err.code || 'NG_ADAPTER_ERROR',
+          message: isTimeout
+            ? `Timed out after ${timeoutMs}ms`
+            : err.message || String(err),
+          retryable: true,
+        },
       };
     }
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,12 @@ export enum Platform {
   BROWSER = 'browser',
 }
 
+export interface AdapterError {
+  code: string;
+  message: string;
+  retryable: boolean;
+}
+
 export interface AdapterResponse {
   domain: string;
   availability: Availability;
@@ -32,10 +38,10 @@ export interface AdapterResponse {
     | 'registered_not_in_use'
     | 'premium'
     | 'for_sale'
-    | 'reserved';
+  | 'reserved';
   source: AdapterSource;
   raw: any;
-  error?: Error;
+  error?: AdapterError;
 }
 
 export interface DomainStatus {
@@ -50,9 +56,9 @@ export interface DomainStatus {
   resolver: AdapterSource;
   /**
    * Raw responses from each adapter keyed by its namespace.
-   */
+  */
   raw: Record<string, any>;
-  error?: Error;
+  error?: AdapterError;
 }
 
 export type ParsedDomain = ParseResult;

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -19,9 +19,11 @@ export function validateDomain(parsed: ParsedDomain, originalDomain: string): Do
       availability: "invalid",
       resolver: "validator",
       raw: { validator: null },
-      error: new Error(
-        `Parse error: originalDomain: ${originalDomain}, parsedName: ${parsed.domain}, tld: ${parsed.publicSuffix}`
-      ),
+      error: {
+        code: "PARSE_ERROR",
+        message: `Parse error: originalDomain: ${originalDomain}, parsedName: ${parsed.domain}, tld: ${parsed.publicSuffix}`,
+        retryable: false,
+      },
     };
   }
 
@@ -33,7 +35,11 @@ export function validateDomain(parsed: ParsedDomain, originalDomain: string): Do
       availability: "unsupported",
       resolver: "validator",
       raw: { validator: null },
-      error: new Error(`TLD is not ICANN supported`),
+      error: {
+        code: "UNSUPPORTED_TLD",
+        message: `TLD is not ICANN supported`,
+        retryable: false,
+      },
     };
   }
 
@@ -45,7 +51,11 @@ export function validateDomain(parsed: ParsedDomain, originalDomain: string): Do
       availability: "unsupported",
       resolver: "validator",
       raw: { validator: null },
-      error: Error(`The library does not support the tld .${suffix}`),
+      error: {
+        code: "UNSUPPORTED_TLD",
+        message: `The library does not support the tld .${suffix}`,
+        retryable: false,
+      },
     };
   }
 

--- a/tests/run.test.js
+++ b/tests/run.test.js
@@ -61,7 +61,7 @@ async function runTest(domains, opts = {}) {
       console.log(`PASSED: ${msg}`);
       pass++;
     } else {
-      const failMsg = `FAILED: ${msg}\n\t${res.error ?? 'No error message provided'}`;
+      const failMsg = `FAILED: ${msg}\n\t${res.error?.message ?? 'No error message provided'}`;
       console.error(`\x1b[31m${failMsg}\x1b[0m`);
     }
   }


### PR DESCRIPTION
## Summary
- introduce `AdapterError` interface and update types to use it
- handle retryable vs non-retryable errors in adapters and cache
- adapt tests and consumers to new error shape

## Testing
- `npm test` *(fails: Value is not `true`)*

------
https://chatgpt.com/codex/tasks/task_b_68a50d3785c0832684565aa67821dd08