### PR TITLE
Deduplicate domain lists in batch APIs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,10 @@ function adapterAllowed(ns: string, opts: CheckOptions): boolean {
   return true;
 }
 
+function normalizeDomains(domains: string[]): string[] {
+  return Array.from(new Set(domains.map((d) => d.trim().toLowerCase())));
+}
+
 export async function check(domain: string, opts: CheckOptions = {}): Promise<DomainStatus> {
   const logger: Pick<Console, 'info' | 'warn' | 'error'> = opts.verbose
     ? opts.logger ?? console
@@ -176,7 +180,7 @@ export async function* checkBatchStream(
   domains: string[],
   opts: CheckOptions = {}
 ): AsyncGenerator<DomainStatus> {
-  const queue = [...domains];
+  const queue = [...normalizeDomains(domains)];
   const concurrency = opts.concurrency ?? MAX_CONCURRENCY;
   const active: Array<{ id: number; promise: Promise<{ id: number; res: DomainStatus }> }> = [];
   let idCounter = 0;

--- a/tests/run.test.js
+++ b/tests/run.test.js
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { checkBatchStream } from '../dist/index.js';
+import { checkBatchStream, checkBatch } from '../dist/index.js';
 import unavailableDomainsJson from '../src/unavailable-domains.json' with { type: 'json' };
 import supportedTlDs from '../src/tlds.json' with { type: 'json' };
 
@@ -67,6 +67,11 @@ async function runTest(domains, opts = {}) {
   }
   return { pass, total: uniqueNames.length };
 }
+
+test('checkBatch removes duplicate domains', async (t) => {
+  const results = await checkBatch([' Example.invalidtld ', 'example.INVALIDTLD']);
+  t.deepEqual(results.map((r) => r.domain), ['example.invalidtld']);
+});
 
 test.serial('validator tests', async (t) => {
   const specialDomains = [


### PR DESCRIPTION
## Summary
- rely on `checkBatchStream`'s normalization and simplify `checkBatch`
- move duplicate-domain check into main test suite and drop extra test file
- revert README changes around dedupe behavior

## Testing
- `npm test` *(fails: Value is not `true`)*
- `npx ava tests/run.test.js --match "checkBatch removes duplicate domains"`


------
https://chatgpt.com/codex/tasks/task_b_68a50f560f788326ac0bfbb23b7648ff