### PR TITLE
feat: add altstatus adapter

### DIFF
--- a/src/adapters/altStatusAdapter.ts
+++ b/src/adapters/altStatusAdapter.ts
@@ -1,0 +1,99 @@
+import { AdapterResponse, ParsedDomain } from '../types';
+import { BaseCheckerAdapter } from './baseAdapter';
+
+const DEFAULT_TIMEOUT_MS = 1000;
+
+export class AltStatusAdapter extends BaseCheckerAdapter {
+  private domainrKey?: string;
+  constructor(domainrKey?: string) {
+    super('altstatus');
+    this.domainrKey = domainrKey;
+  }
+
+  private async fetchDomainr(domain: string, timeoutMs: number): Promise<any> {
+    if (!this.domainrKey) throw new Error('domainr api key missing');
+    const url = `https://domainr.p.rapidapi.com/v2/status?domain=${domain}&mashape-key=${this.domainrKey}`;
+    const ac = new AbortController();
+    const timer = setTimeout(() => ac.abort(), timeoutMs);
+    const res = await fetch(url, { signal: ac.signal });
+    clearTimeout(timer);
+    const text = await res.text();
+    if (!res.ok) {
+      const err: any = new Error(`domainr failed: ${res.status}`);
+      err.quota = res.status === 429 || /quota|limit/i.test(text);
+      throw err;
+    }
+    return JSON.parse(text);
+  }
+
+  private async fetchMono(domain: string, timeoutMs: number): Promise<any> {
+    const url = `https://api.mono.domains/availability/${domain}`;
+    const ac = new AbortController();
+    const timer = setTimeout(() => ac.abort(), timeoutMs);
+    const res = await fetch(url, { signal: ac.signal });
+    clearTimeout(timer);
+    const text = await res.text();
+    if (!res.ok) throw new Error(`mono domains failed: ${res.status}`);
+    return JSON.parse(text);
+  }
+
+  protected async doCheck(
+    domainObj: ParsedDomain,
+    opts: { timeoutMs?: number } = {},
+  ): Promise<AdapterResponse> {
+    const domain = domainObj.domain as string;
+    const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    try {
+      if (this.domainrKey) {
+        try {
+          const data = await this.fetchDomainr(domain, timeoutMs);
+          const summary = data?.status?.[0]?.summary;
+          const isAvailable = summary === 'inactive';
+          return {
+            domain,
+            availability: isAvailable ? 'available' : 'unavailable',
+            source: 'altstatus.domainr',
+            raw: data,
+          };
+        } catch (err) {
+          // fallthrough to mono
+        }
+      }
+      const monoData = await this.fetchMono(domain, timeoutMs);
+      if (!monoData?.success) {
+        throw new Error('mono domains failed');
+      }
+      return {
+        domain,
+        availability: monoData.isDomainAvailable ? 'available' : 'unavailable',
+        source: 'altstatus.mono',
+        raw: monoData,
+      };
+    } catch (err: any) {
+      const message = err?.message || String(err);
+      let code = err?.code || 'STATUS_API_ERROR';
+      let retryable = true;
+      if (/api key missing/i.test(message)) {
+        code = 'API_KEY_MISSING';
+        retryable = false;
+      } else if (err?.quota || /429/.test(message)) {
+        code = 'RATE_LIMIT';
+        retryable = true;
+      } else if (err?.name === 'AbortError' || /timed out/i.test(message)) {
+        code = 'TIMEOUT';
+        retryable = true;
+      }
+      return {
+        domain,
+        availability: 'unknown',
+        source: 'altstatus',
+        raw: null,
+        error: {
+          code,
+          message,
+          retryable,
+        },
+      };
+    }
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,9 @@ export type AdapterSource =
   | 'dns.doh'
   | 'rdap'
   | 'rdap.ng'
+  | 'altstatus'
+  | 'altstatus.domainr'
+  | 'altstatus.mono'
   | 'whois.lib'
   | 'whois.api'
   | 'app';

--- a/tests/run.test.js
+++ b/tests/run.test.js
@@ -155,6 +155,24 @@ test.serial.skip('whois.api unavailable status tests', async (t) => {
   t.true(pass / total >= 0.80);
 });
 
+test.serial('altstatus available status test', async (t) => {
+  const domains = [
+    { name: 'this-domain-should-not-exist-12345.com', availability: 'available' },
+  ];
+  const { pass, total } = await runTest(domains, { only: ['altstatus'] });
+  console.log(`altstatus available status test results: ${(pass * 100 / total).toFixed(2)}%`);
+  testSummary.altStatusAvailable = { pass, total, cutoff: 1 };
+  t.true(pass / total >= 1);
+});
+
+test.serial('altstatus unavailable status test', async (t) => {
+  const domains = [{ name: 'example.com', availability: 'unavailable' }];
+  const { pass, total } = await runTest(domains, { only: ['altstatus'] });
+  console.log(`altstatus unavailable status test results: ${(pass * 100 / total).toFixed(2)}%`);
+  testSummary.altStatusUnavailable = { pass, total, cutoff: 1 };
+  t.true(pass / total >= 1);
+});
+
 test.serial('rdap available status tests', async (t) => {
   const { pass, total } = await runTest(availableDomains, { only: ['rdap'] });
   console.log(`rdap available status test results: ${(pass * 100 / total).toFixed(2)}%`);


### PR DESCRIPTION
## Summary
- rename status API adapter to AltStatus with DomainR and Mono implementations
- insert AltStatus adapter between RDAP and WHOIS checks
- update adapter source types and tests for altstatus namespaces

## Testing
- `npm test` *(fails: network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68a778d6bb308326bc6b623c784558e9