### PR TITLE
feat: allow passing API keys via options

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ interface CheckOptions {
   tldConfig?: TldConfigEntry;
   platform?: 'auto' | 'node' | 'browser';
   cache?: boolean;      // enable or disable caching (default true)
+  apiKeys?: {
+    domainr?: string;
+    whoisfreaks?: string;
+    whoisxml?: string;
+  };
 }
 ```
 
@@ -77,13 +82,23 @@ Logging is disabled unless `verbose` is set. When `platform` is `auto` the
 library detects the runtime and chooses suitable adapters. Set `cache: false`
 to disable caching.
 
-### WHOIS API Keys
+### API Keys
 
 When running in the browser or when a WHOIS lookup is required, the library can
-use paid APIs. Provide credentials through the following environment variables:
+use paid APIs. Provide credentials via the `apiKeys` option:
 
-- `WHOISFREAKS_API_KEY`
-- `WHOISXML_API_KEY`
+```ts
+check('example.com', {
+  apiKeys: {
+    domainr: 'DOMAINR_KEY',
+    whoisfreaks: 'WHOISFREAKS_KEY',
+    whoisxml: 'WHOISXML_KEY'
+  }
+});
+```
+
+The library does not read environment variables for credentials; all API keys
+must be supplied explicitly through `apiKeys`.
 
 ## Demo
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,14 +22,7 @@ const host = new HostAdapter();
 const ping = new PingAdapter();
 const doh = new DohAdapter();
 const rdap = new RdapAdapter();
-const altStatus = new AltStatusAdapter(
-  typeof process !== 'undefined' ? (process.env.DOMAINR_API_KEY as string | undefined) : undefined,
-);
 const whoisLib = new WhoisLibAdapter();
-const whoisApi = new WhoisApiAdapter(
-  typeof process !== 'undefined' ? (process.env.WHOISFREAKS_API_KEY as string | undefined) : undefined,
-  typeof process !== 'undefined' ? (process.env.WHOISXML_API_KEY as string | undefined) : undefined
-);
 const noopLogger: Pick<Console, 'info' | 'warn' | 'error'> = {
   info: () => {},
   warn: () => {},
@@ -80,6 +73,12 @@ export async function check(domain: string, opts: CheckOptions = {}): Promise<Do
   }
   const name = parsed.domain!;
   const tldAdapter = getTldAdapter(parsed.publicSuffix);
+
+  const altStatus = new AltStatusAdapter(opts.apiKeys?.domainr);
+  const whoisApi = new WhoisApiAdapter(
+    opts.apiKeys?.whoisfreaks,
+    opts.apiKeys?.whoisxml,
+  );
 
   try {
     let finalError: AdapterError | undefined;

--- a/src/tldAdapters/ngAdapter.ts
+++ b/src/tldAdapters/ngAdapter.ts
@@ -15,7 +15,7 @@ export class NgAdapter extends BaseCheckerAdapter {
     const ac = new AbortController();
     const timer = setTimeout(() => ac.abort(), timeoutMs);
     // This bypasses secure connection, their cert is expired.
-    // process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+    // (TLS checks must be disabled externally if required)
     try {
       const res = await fetch(
         `https://whois.nic.net.ng/domains?name=${domain}&exactMatch=true`,

--- a/src/types.ts
+++ b/src/types.ts
@@ -97,4 +97,12 @@ export interface CheckOptions {
    * Enable or disable caching. Caching is enabled by default.
    */
   cache?: boolean;
+  /**
+   * API keys for third-party services.
+   */
+  apiKeys?: {
+    domainr?: string;
+    whoisfreaks?: string;
+    whoisxml?: string;
+  };
 }


### PR DESCRIPTION
## Summary
- add `apiKeys` to `CheckOptions` for domainr and whois services
- instantiate adapters using provided API keys only
- document new API key configuration

## Testing
- `npm test` *(fails: 12 tests failed, 2 tests skipped)*


------
https://chatgpt.com/codex/tasks/task_b_68a77e002b188326a0038d33c1e01aa3