### PR TITLE
Add type declarations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,10 +14,23 @@
       "bin": {
         "domainstat": "dist/cli.js"
       },
-      "devDependencies": {},
+      "devDependencies": {
+        "@types/node": "^24.5.2",
+        "typescript": "^5.9.2"
+      },
       "engines": {
         "node": "^22.12.0",
         "npm": "^10.9.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.2.tgz",
+      "integrity": "sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.12.0"
       }
     },
     "node_modules/tldts": {
@@ -35,6 +48,27 @@
       "version": "7.0.12",
       "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.12.tgz",
       "integrity": "sha512-3K76aXywJFduGRsOYoY5JzINLs/WMlOkeDwPL+8OCPq2Rh39gkSDtWAxdJQlWjpun/xF/LHf29yqCi6VC/rHDA=="
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz",
+      "integrity": "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "./dist/index.js",
   "scripts": {
     "build": "npm run build:lib && npm run build:cli",
-    "build:lib": "npx -y esbuild src/index.ts --bundle --minify --format=esm --target=es2020 --outdir=dist/ --platform=neutral",
+    "build:lib": "npx -y esbuild src/index.ts --bundle --minify --format=esm --target=es2020 --outdir=dist/ --platform=neutral && tsc --emitDeclarationOnly",
     "build:cli": "npx -y esbuild src/cli.ts --bundle --minify --format=esm --target=node20 --outfile=dist/cli.js --platform=node",
     "test": "npm run build && node --test",
     "start": "npm run build && cp dist/index.js demo/index.js && npx serve demo"
@@ -41,5 +41,8 @@
   "dependencies": {
     "tldts": "^7.0.10"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "@types/node": "^24.5.2",
+    "typescript": "^5.9.2"
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import { DohAdapter } from './adapters/dohAdapter';
 import { RdapAdapter } from './adapters/rdapAdapter';
 import { WhoisApiAdapter } from './adapters/whoisApiAdapter';
 import { getTldAdapter } from './tldAdapters';
-import { AdapterError, AdapterResponse, AdapterSource, CheckOptions, DomainStatus } from './types';
+import { AdapterError, AdapterResponse, AdapterSource, Availability, CheckOptions, DomainStatus } from './types';
 import { validateDomain } from './validator';
 export type { DomainStatus } from './types';
 
@@ -241,8 +241,8 @@ export async function checkSerial(domain: string, opts: CheckOptions = {}): Prom
 
   const finalResult = result ?? {
     domain: name,
-    availability: 'unknown',
-    resolver: 'app',
+    availability: 'unknown' as Availability,
+    resolver: 'app' as AdapterSource,
     raw,
     latencies,
     error: finalError,

--- a/src/tldAdapters/index.ts
+++ b/src/tldAdapters/index.ts
@@ -14,7 +14,7 @@ export const tldAdapters: Record<string, TldAdapter> = {
   'net.ng': { rdap: new NgAdapter('rdap', 'rdap.ng') },
 };
 
-export function getTldAdapter(suffix?: string): TldAdapter | undefined {
+export function getTldAdapter(suffix: string | null): TldAdapter | undefined {
   if (!suffix) return undefined;
   const lower = suffix.toLowerCase();
   if (tldAdapters[lower]) return tldAdapters[lower];

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import type { ParseResult } from 'tldts';
+import type { IResult } from 'tldts-core';
 
 export type Availability = 'unregistered' | 'registered' | 'unsupported' | 'invalid' | 'unknown';
 
@@ -51,7 +51,7 @@ export interface DomainStatus {
   error?: AdapterError;
 }
 
-export type ParsedDomain = ParseResult;
+export type ParsedDomain = IResult;
 
 export interface CheckerAdapter {
   /** Unique identifier used to store results for this adapter */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
     "resolveJsonModule": true,
     "strict": true,
     "skipLibCheck": true,
-    "outDir": "dist"
+    "outDir": "dist",
+    "declaration": true
   },
   "include": ["src/**/*", "tests/**/*"]
 }


### PR DESCRIPTION
This PR adds type declarations with tsc.
If you want to use the library in TypeScript projects you'd get the following error without type declarations present.
```
Could not find a declaration file for module 'domainstat'. '…/node_modules/domainstat/dist/index.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/domainstat` if it exists or add a new declaration (.d.ts) file containing `declare module 'domainstat';`
```

tsc complained about a few type errors in the process, so I fixed those.